### PR TITLE
Add crux links and tags to posts that became crux functions

### DIFF
--- a/_posts/2013-03-27-open-file-in-external-program.markdown
+++ b/_posts/2013-03-27-open-file-in-external-program.markdown
@@ -5,7 +5,7 @@ date: 2013-03-27 12:44
 comments: true
 tags:
 - Utilities
-- Crux
+- crux
 ---
 
 Sometimes it's useful to be able to open the file you're editing in
@@ -41,5 +41,6 @@ I find it convenient to bind the command to `C-c o`:
 (global-set-key (kbd "C-c o") #'er-open-with)
 ```
 
-[crux](https://github.com/bbatsov/crux) features a variant of this
-commands. (it is named `crux-open-with`).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-open-with`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-03-30-kill-other-buffers.markdown
+++ b/_posts/2013-03-30-kill-other-buffers.markdown
@@ -5,6 +5,7 @@ date: 2013-03-30 15:50
 comments: true
 tags:
 - Utilities
+- crux
 ---
 
 Many text editors and IDEs offer the ability to close all open files
@@ -54,3 +55,7 @@ Doesn't mess with special buffers."
 According to your personal preference on functional programming the
 second version might seem either much more elegant, ghastly or just the
 same as the original.
+
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-kill-other-buffers`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-04-03-delete-file-and-buffer.markdown
+++ b/_posts/2013-04-03-delete-file-and-buffer.markdown
@@ -6,6 +6,7 @@ comments: true
 tags:
 - Utilities
 - Emacs Lisp
+- crux
 ---
 
 From time to time[^1] I need to quickly[^2] delete a file and kill the
@@ -39,8 +40,9 @@ command we should probably bind it to some each to press keys, like `C-c D`:
 (global-set-key (kbd "C-c D")  #'er-delete-file-and-buffer)
 ```
 
-As usual both the command and its keybinding are available in
-[Prelude](https://github.com/bbatsov/prelude).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-delete-file-and-buffer`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.
 
 [^1]: Most often when I refactor code.
 [^2]: This removes `dired` from the equation.

--- a/_posts/2013-04-09-kill-whole-line.markdown
+++ b/_posts/2013-04-09-kill-whole-line.markdown
@@ -5,6 +5,7 @@ date: 2013-04-09 14:49
 comments: true
 tags:
 - Editing
+- crux
 ---
 
 Let's continue our exploration of the fascinating topic of
@@ -39,5 +40,6 @@ Now we can rebind `C-S-Backspace`.
 `remap` is a pretty neat trick in its own right; maybe I'll write a
 bit more about it in the future.
 
-The `smart-kill-whole-line` command is available out-of-the-box in
-[Prelude](https://github.com/bbatsov/prelude).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-kill-whole-line`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-04-21-edit-files-as-root.markdown
+++ b/_posts/2013-04-21-edit-files-as-root.markdown
@@ -5,6 +5,7 @@ date: 2013-04-21 10:03
 comments: true
 tags:
 - Utilities
+- crux
 ---
 
 One area where Emacs traditionally falls short by default is editing
@@ -82,3 +83,7 @@ alias E="SUDO_EDITOR=\"emacsclient -t -a emacs\" sudoedit"
 ```
 
 This should (will) finally save you from reaching for `vim` in the terminal!
+
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-sudo-edit`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-04-28-switch-to-previous-buffer.markdown
+++ b/_posts/2013-04-28-switch-to-previous-buffer.markdown
@@ -5,6 +5,7 @@ date: 2013-04-28 08:43
 comments: true
 tags:
 - Utilities
+- crux
 ---
 
 Jumping between the current buffer and the one you were in before is a
@@ -38,4 +39,6 @@ If you're not fond of key chords I'd suggest a good old keybinding instead:
 (global-set-key (kbd "C-c b") #'er-switch-to-previous-buffer)
 ```
 
-The command and its key chord are part of [Prelude](https://github.com/bbatsov/prelude).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-switch-to-previous-buffer`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-05-04-rename-file-and-buffer.markdown
+++ b/_posts/2013-05-04-rename-file-and-buffer.markdown
@@ -53,7 +53,6 @@ command we should probably bind it to some each to press keys, like `C-c r`:
 (global-set-key (kbd "C-c r")  #'er-rename-file-and-buffer)
 ```
 
-As usual both the command and its keybinding are available in
-[Prelude](https://github.com/bbatsov/prelude).[^1]
-
-[^1]: Technically speaking the command is part of [crux](https://github.com/bbatsov/crux).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-rename-file-and-buffer`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-05-18-instant-access-to-init-dot-el.markdown
+++ b/_posts/2013-05-18-instant-access-to-init-dot-el.markdown
@@ -5,6 +5,7 @@ date: 2013-05-18 19:00
 comments: true
 tags:
 - Utilities
+- crux
 ---
 
 One of the files Emacs users often edit is `init.el`(especially if they
@@ -30,3 +31,7 @@ Short and sweet! You might want to bind it to some keycombo:
 
 Thanks to [Sebastian Wiesner](https://github.com/lunaryorn) for
 bringing this tip to my attention!
+
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-find-user-init-file`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-05-22-smarter-navigation-to-the-beginning-of-a-line.markdown
+++ b/_posts/2013-05-22-smarter-navigation-to-the-beginning-of-a-line.markdown
@@ -5,6 +5,7 @@ date: 2013-05-22 17:48
 comments: true
 tags:
 - Editing
+- crux
 ---
 
 In Emacs there are two essential commands when you have to go the
@@ -69,6 +70,8 @@ This is a short example
 
 This functionality could also be implemented with `defadvice`, but I tend to avoid their use.
 
-`smarter-move-beginning-of-line` is part of [Prelude](https://github.com/bbatsov/prelude).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-move-beginning-of-line`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.
 
 **P.S.** The credit for this tip goes to [Sebastian Wiesner](https://github.com/lunaryorn).

--- a/_posts/2013-05-30-joining-lines.markdown
+++ b/_posts/2013-05-30-joining-lines.markdown
@@ -5,6 +5,7 @@ date: 2013-05-30 16:27
 comments: true
 tags:
 - Editing
+- crux
 ---
 
 Often, while editing, you'll want to compress a few lines into
@@ -50,6 +51,7 @@ sense to use something like `C-^` for the new command:
 
 That's mostly a personal preference I guess - feel free to use any other keycombo.
 
-This command is part of
-[Prelude](https://github.com/bbatsov/prelude)(it's named
-`prelude-top-join-line` there) and it's bound to `C-^` there.
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-top-join-line`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package, and is
+bound to `C-^` there.

--- a/_posts/2013-06-15-open-line-above.markdown
+++ b/_posts/2013-06-15-open-line-above.markdown
@@ -5,6 +5,7 @@ date: 2013-06-15 09:04
 comments: true
 tags:
 - Editing
+- crux
 ---
 
 This post continues a topic that was introduced in
@@ -17,7 +18,7 @@ and position the cursor at its beginning.  Such a feature is present
 in most IDEs, such as IntelliJ IDEA, Eclipse and NetBeans. It’s
 sometimes bound to `Control+Shift+Enter`. Last time I showed you how
 to implement a similar function called `smart-open-line`, this time
-will implement `smart-open-line-above`. Just add this snippet to your
+we will implement `smart-open-line-above`. Just add this snippet to your
 `.emacs` (or `.emacs.d/init.el` or whatever):
 
 ``` elisp
@@ -50,6 +51,7 @@ Another good option would be to fold the two commands into one and use a
 prefix argument to trigger the opening a new line above the current
 one.
 
-This command is part of
-[Prelude](https://github.com/bbatsov/prelude)(it's named
-`prelude-smart-open-line-above` there).
+These commands are available in [crux](https://github.com/bbatsov/crux) as
+`crux-smart-open-line-above` and `crux-smart-open-line`.
+These commands are also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-06-21-eval-and-replace.markdown
+++ b/_posts/2013-06-21-eval-and-replace.markdown
@@ -5,6 +5,7 @@ date: 2013-06-21 12:35
 comments: true
 tags:
 - Utilities
+- crux
 ---
 
 Sometimes people tend to overlook how well Emacs and Emacs Lisp are
@@ -43,6 +44,6 @@ expression. Pretty neat!
 
 I'll leave it up to you to think of more creative applications of the command.
 
-This command is part of
-[Prelude](https://github.com/bbatsov/prelude)(it's named
-`prelude-eval-and-replace` there).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-eval-and-replace`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.

--- a/_posts/2013-09-27-instant-access-to-your-shell-init-file.markdown
+++ b/_posts/2013-09-27-instant-access-to-your-shell-init-file.markdown
@@ -37,6 +37,6 @@ in.
 (global-set-key (kbd "C-c S") #'er-find-shell-init-file)
 ```
 
-`er-find-shell-init-file` is available in
-[crux](https://github.com/bbatsov/crux) (but with a `crux-`
-prefix).
+This command is available in [crux](https://github.com/bbatsov/crux) as
+`crux-find-shell-init-file`. This command is also available in
+[prelude](https://github.com/bbatsov/prelude) via the crux package.


### PR DESCRIPTION
A bunch of functions which started life on emacsredux + Prelude have migrated to https://www.github.com/bbatsov/crux. This commit adds links to crux from those blog posts, and tags the posts. Some of the footer mentions were a little bit awkward to include Prelude and Crux. I can reword them if you'd like.

Relates to https://github.com/bbatsov/crux/pull/64.